### PR TITLE
Generate Champions League HTML table from CSV

### DIFF
--- a/data/champions_league_club_logos.csv
+++ b/data/champions_league_club_logos.csv
@@ -1,0 +1,11 @@
+year,club,logo,country
+2023,Manchester City,https://upload.wikimedia.org/wikipedia/en/e/eb/Manchester_City_FC_badge.svg,England
+2022,Real Madrid,https://upload.wikimedia.org/wikipedia/en/5/56/Real_Madrid_CF.svg,Spain
+2021,Chelsea,https://upload.wikimedia.org/wikipedia/en/c/cc/Chelsea_FC.svg,England
+2020,Bayern Munich,https://upload.wikimedia.org/wikipedia/en/1/1f/FC_Bayern_M%C3%BCnchen_logo_%282017%29.svg,Germany
+2019,Liverpool,https://upload.wikimedia.org/wikipedia/en/0/0c/Liverpool_FC.svg,England
+2018,Real Madrid,https://upload.wikimedia.org/wikipedia/en/5/56/Real_Madrid_CF.svg,Spain
+2017,Real Madrid,https://upload.wikimedia.org/wikipedia/en/5/56/Real_Madrid_CF.svg,Spain
+2016,Real Madrid,https://upload.wikimedia.org/wikipedia/en/5/56/Real_Madrid_CF.svg,Spain
+2015,Barcelona,https://upload.wikimedia.org/wikipedia/en/4/47/FC_Barcelona_%28crest%29.svg,Spain
+2014,Real Madrid,https://upload.wikimedia.org/wikipedia/en/5/56/Real_Madrid_CF.svg,Spain

--- a/public/champions_league_table.html
+++ b/public/champions_league_table.html
@@ -1,0 +1,59 @@
+
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="utf-8">
+    <title>Clubs vainqueurs de la Ligue des champions</title>
+    <style>
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f5f7fa;
+    padding: 2rem;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: #ffffff;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+thead th {
+    background-color: #1a237e;
+    color: #ffffff;
+    padding: 12px;
+    text-align: left;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.85rem;
+}
+
+tbody td {
+    padding: 12px;
+    border-bottom: 1px solid #e0e0e0;
+    vertical-align: middle;
+}
+
+tbody tr:nth-child(even) {
+    background-color: #f0f3ff;
+}
+
+td img {
+    height: 48px;
+    width: auto;
+}
+
+@media (min-width: 768px) {
+    table {
+        max-width: 960px;
+        margin: 0 auto;
+    }
+}
+</style>
+</head>
+<body>
+    <h1>Clubs vainqueurs de la Ligue des champions</h1>
+    <p>Tableau généré automatiquement à partir du fichier CSV <code>champions_league_club_logos.csv</code>.</p>
+    <table><thead><tr><th>Année</th><th>Club</th><th>Logo</th><th>Pays</th></tr></thead><tbody><tr><td>2023</td><td>Manchester City</td><td><img src="https://upload.wikimedia.org/wikipedia/en/e/eb/Manchester_City_FC_badge.svg" alt="Logo Manchester City"></td><td>England</td></tr><tr><td>2022</td><td>Real Madrid</td><td><img src="https://upload.wikimedia.org/wikipedia/en/5/56/Real_Madrid_CF.svg" alt="Logo Real Madrid"></td><td>Spain</td></tr><tr><td>2021</td><td>Chelsea</td><td><img src="https://upload.wikimedia.org/wikipedia/en/c/cc/Chelsea_FC.svg" alt="Logo Chelsea"></td><td>England</td></tr><tr><td>2020</td><td>Bayern Munich</td><td><img src="https://upload.wikimedia.org/wikipedia/en/1/1f/FC_Bayern_M%C3%BCnchen_logo_%282017%29.svg" alt="Logo Bayern Munich"></td><td>Germany</td></tr><tr><td>2019</td><td>Liverpool</td><td><img src="https://upload.wikimedia.org/wikipedia/en/0/0c/Liverpool_FC.svg" alt="Logo Liverpool"></td><td>England</td></tr><tr><td>2018</td><td>Real Madrid</td><td><img src="https://upload.wikimedia.org/wikipedia/en/5/56/Real_Madrid_CF.svg" alt="Logo Real Madrid"></td><td>Spain</td></tr><tr><td>2017</td><td>Real Madrid</td><td><img src="https://upload.wikimedia.org/wikipedia/en/5/56/Real_Madrid_CF.svg" alt="Logo Real Madrid"></td><td>Spain</td></tr><tr><td>2016</td><td>Real Madrid</td><td><img src="https://upload.wikimedia.org/wikipedia/en/5/56/Real_Madrid_CF.svg" alt="Logo Real Madrid"></td><td>Spain</td></tr><tr><td>2015</td><td>Barcelona</td><td><img src="https://upload.wikimedia.org/wikipedia/en/4/47/FC_Barcelona_%28crest%29.svg" alt="Logo Barcelona"></td><td>Spain</td></tr><tr><td>2014</td><td>Real Madrid</td><td><img src="https://upload.wikimedia.org/wikipedia/en/5/56/Real_Madrid_CF.svg" alt="Logo Real Madrid"></td><td>Spain</td></tr></tbody></table>
+</body>
+</html>

--- a/scripts/generate_html_table.py
+++ b/scripts/generate_html_table.py
@@ -1,0 +1,102 @@
+import csv
+from pathlib import Path
+
+DATA_PATH = Path(__file__).resolve().parents[1] / "data" / "champions_league_club_logos.csv"
+OUTPUT_PATH = Path(__file__).resolve().parents[1] / "public" / "champions_league_table.html"
+
+TABLE_STYLE = """
+body {
+    font-family: Arial, sans-serif;
+    background-color: #f5f7fa;
+    padding: 2rem;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    background-color: #ffffff;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+thead th {
+    background-color: #1a237e;
+    color: #ffffff;
+    padding: 12px;
+    text-align: left;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.85rem;
+}
+
+tbody td {
+    padding: 12px;
+    border-bottom: 1px solid #e0e0e0;
+    vertical-align: middle;
+}
+
+tbody tr:nth-child(even) {
+    background-color: #f0f3ff;
+}
+
+td img {
+    height: 48px;
+    width: auto;
+}
+
+@media (min-width: 768px) {
+    table {
+        max-width: 960px;
+        margin: 0 auto;
+    }
+}
+"""
+
+
+def build_table(rows):
+    header = "<thead><tr><th>Année</th><th>Club</th><th>Logo</th><th>Pays</th></tr></thead>"
+    body_cells = []
+    for row in rows:
+        year, club, logo, country = row
+        body_cells.append(
+            "<tr>"
+            f"<td>{year}</td>"
+            f"<td>{club}</td>"
+            f"<td><img src=\"{logo}\" alt=\"Logo {club}\"></td>"
+            f"<td>{country}</td>"
+            "</tr>"
+        )
+    body = "<tbody>" + "".join(body_cells) + "</tbody>"
+    return "<table>" + header + body + "</table>"
+
+
+def main():
+    if not DATA_PATH.exists():
+        raise FileNotFoundError(f"Le fichier CSV est introuvable: {DATA_PATH}")
+
+    with DATA_PATH.open(newline="", encoding="utf-8") as csvfile:
+        reader = csv.reader(csvfile)
+        next(reader, None)  # skip header
+        rows = list(reader)
+
+    table_html = build_table(rows)
+    page_html = f"""
+<!DOCTYPE html>
+<html lang=\"fr\">
+<head>
+    <meta charset=\"utf-8\">
+    <title>Clubs vainqueurs de la Ligue des champions</title>
+    <style>{TABLE_STYLE}</style>
+</head>
+<body>
+    <h1>Clubs vainqueurs de la Ligue des champions</h1>
+    <p>Tableau généré automatiquement à partir du fichier CSV <code>champions_league_club_logos.csv</code>.</p>
+    {table_html}
+</body>
+</html>
+"""
+
+    OUTPUT_PATH.write_text(page_html, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Champions League winners CSV with logo URLs and country metadata
- create a Python utility that reads the CSV and renders an HTML grid
- generate a styled HTML table presenting the data in four columns

## Testing
- python3 scripts/generate_html_table.py

------
https://chatgpt.com/codex/tasks/task_e_68da52d524908326976528aa4eebc23d